### PR TITLE
Add standalone main launcher

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+"""Entry point for launching the VatiVision Pro client application."""
+
+from vativision_pro_client import main as run_app
+
+
+if __name__ == "__main__":
+    run_app()

--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -524,6 +524,3 @@ def main():
     w = Main(); w.show()
     with loop:
         loop.run_forever()
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- add a dedicated `main.py` entry point that launches the VatiVision Pro client
- keep the application's `main()` function importable without side effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93cdd3dd08327adf95c1d18be5201