### PR TITLE
Set application icon to bundled logo

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -3,6 +3,7 @@
 import asyncio, json
 from time import perf_counter
 from typing import Optional
+from pathlib import Path
 
 from PySide6 import QtWidgets, QtCore, QtGui
 from qasync import QEventLoop
@@ -17,6 +18,7 @@ ROOM_NAME    = "VATI-ROOM"
 ROOM_PIN     = "428913"
 STUN_URLS    = ["stun:stun.l.google.com:19302"]
 APP_TITLE    = "VatiVision Pro — Kliens (Ping + TURN + Sávszél + Képernyő)"
+APP_ICON_PATH = Path(__file__).resolve().parent / "program_logo.png"
 
 BW_SECONDS   = 5.0
 BW_CHUNK     = 16 * 1024
@@ -343,6 +345,9 @@ class Main(QtWidgets.QMainWindow):
         super().__init__()
         self.setWindowTitle(APP_TITLE)
         self.resize(1200, 720)
+        if APP_ICON_PATH.exists():
+            icon = QtGui.QIcon(str(APP_ICON_PATH))
+            self.setWindowIcon(icon)
 
         central = QtWidgets.QWidget(); self.setCentralWidget(central)
         root = QtWidgets.QHBoxLayout(central); root.setContentsMargins(12,12,12,12); root.setSpacing(12)
@@ -520,6 +525,8 @@ class Main(QtWidgets.QMainWindow):
 def main():
     app = QtWidgets.QApplication([])
     app.setStyleSheet(style())
+    if APP_ICON_PATH.exists():
+        app.setWindowIcon(QtGui.QIcon(str(APP_ICON_PATH)))
     loop = QEventLoop(app); asyncio.set_event_loop(loop)
     w = Main(); w.show()
     with loop:


### PR DESCRIPTION
## Summary
- load the bundled program_logo.png path using pathlib
- apply the logo as both the main window icon and the application icon when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93cefce888327bbf4076eba7b40b9