### PR TITLE
Improve screen sharing capture reliability

### DIFF
--- a/vati_screenshare.py
+++ b/vati_screenshare.py
@@ -1,8 +1,8 @@
-
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import numpy as np
 from mss import mss
@@ -18,27 +18,113 @@ RESOLUTIONS = {
     "1080p (1920×1080)":(1920, 1080),
 }
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class ShareConfig:
     width: int = 1280
     height: int = 720
     fps: int = 30
+    monitor_index: int = 0
+    region: Optional[Tuple[int, int, int, int]] = None
+
 
 class ScreenShareTrack(VideoStreamTrack):
-    def __init__(self, width: int, height: int, fps: int, monitor_index: int = 1, region: Optional[Tuple[int, int, int, int]] = None):
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        fps: int,
+        monitor_index: int = 0,
+        region: Optional[Tuple[int, int, int, int]] = None,
+    ):
         super().__init__()
         self._size = (int(width), int(height))
         self._fps = int(fps)
-        self._monitor_index = int(monitor_index)
+        self._requested_monitor = int(monitor_index)
+        self._monitor_index = 0
         self._region = region
-        self._sct = mss()
+        self._sct = None
         self._last_ts = 0.0
+        self._init_capture()
 
     def set_size(self, width: int, height: int):
         self._size = (int(width), int(height))
 
     def set_fps(self, fps: int):
         self._fps = int(fps)
+
+    def set_monitor(self, monitor_index: int):
+        self._requested_monitor = int(monitor_index)
+        self._monitor_index = self._sanitize_monitor_index(self._requested_monitor)
+
+    def set_region(self, region: Optional[Tuple[int, int, int, int]]):
+        self._region = region
+
+    def _init_capture(self):
+        try:
+            self._sct = mss()
+        except Exception as exc:
+            logger.exception("Nem sikerült inicializálni az MSS rögzítőt: %s", exc)
+            self._sct = None
+        self._monitor_index = self._sanitize_monitor_index(self._requested_monitor)
+
+    def _sanitize_monitor_index(self, monitor_index: int) -> int:
+        if not self._sct:
+            return 0
+        monitors = getattr(self._sct, "monitors", []) or []
+        if not monitors:
+            logger.warning("Nem található egyetlen monitor sem a képernyőmegosztáshoz.")
+            return 0
+
+        idx = int(monitor_index)
+        max_index = len(monitors) - 1
+        if idx < 0 or idx > max_index:
+            fallback = 1 if max_index >= 1 else 0
+            logger.warning(
+                "Érvénytelen monitor index (%s). Elérhető tartomány: 0..%s – visszaesés %s értékre.",
+                idx,
+                max_index,
+                fallback,
+            )
+            idx = fallback
+        return idx
+
+    def _grab_frame(self) -> VideoFrame:
+        if not self._sct:
+            raise RuntimeError("A képernyő rögzítő nincs inicializálva.")
+
+        monitors = self._sct.monitors
+        if not monitors:
+            raise RuntimeError("Nem található monitor a képernyőmegosztáshoz.")
+
+        if self._monitor_index >= len(monitors):
+            self._monitor_index = self._sanitize_monitor_index(self._monitor_index)
+
+        mon = monitors[self._monitor_index]
+
+        if self._region is not None:
+            left, top, width, height = self._region
+            bbox = {
+                "left": int(mon["left"] + left),
+                "top": int(mon["top"] + top),
+                "width": int(width),
+                "height": int(height),
+            }
+        else:
+            bbox = {
+                "left": int(mon["left"]),
+                "top": int(mon["top"]),
+                "width": int(mon["width"]),
+                "height": int(mon["height"]),
+            }
+
+        raw = self._sct.grab(bbox)
+        img = Image.frombytes("RGB", raw.size, raw.rgb)
+        if self._size and raw.size != self._size:
+            img = img.resize(self._size, Image.LANCZOS)
+        return VideoFrame.from_image(img)
 
     async def recv(self) -> VideoFrame:
         fps = max(1, int(self._fps))
@@ -49,23 +135,22 @@ class ScreenShareTrack(VideoStreamTrack):
             await asyncio.sleep(wait)
         self._last_ts = time.perf_counter()
 
-        mon = self._sct.monitors[self._monitor_index]
-        if self._region is not None:
-            left, top, width, height = self._region
-            bbox = {"left": mon["left"] + left, "top": mon["top"] + top, "width": width, "height": height}
-        else:
-            bbox = {"left": mon["left"], "top": mon["top"], "width": mon["width"], "height": mon["height"]}
-
         try:
-            raw = self._sct.grab(bbox)        # BGRA memory; .rgb provides RGB bytes
-            img = Image.frombytes("RGB", raw.size, raw.rgb)
-            if self._size:
-                img = img.resize(self._size, Image.BILINEAR)
-            frame = VideoFrame.from_ndarray(np.asarray(img), format="rgb24")
-        except Exception:
+            frame = await asyncio.get_running_loop().run_in_executor(None, self._grab_frame)
+        except Exception as exc:
+            logger.exception("Képernyőkép készítése sikertelen: %s", exc)
             w, h = self._size or (640, 360)
             black = np.zeros((h, w, 3), dtype=np.uint8)
             frame = VideoFrame.from_ndarray(black, format="rgb24")
 
         frame.pts, frame.time_base = self.next_timestamp()
         return frame
+
+    async def stop(self) -> None:
+        await super().stop()
+        if self._sct:
+            try:
+                self._sct.close()
+            except Exception:
+                pass
+            self._sct = None


### PR DESCRIPTION
### **User description**
## Summary
- harden the screen capture track against invalid monitor indices and missing displays
- add logging plus graceful fallbacks when screen grabs fail and reuse an executor-based grab helper
- expose monitor and region setters to make the capture configuration adjustable at runtime

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d93dac69048327a06aab18e118a082


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improve screen capture reliability with error handling

- Add monitor index validation and graceful fallbacks

- Expose runtime configuration setters for monitor/region

- Add logging and executor-based frame grabbing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Screen Capture Request"] --> B["Monitor Index Validation"]
  B --> C["MSS Initialization"]
  C --> D["Frame Grabbing"]
  D --> E["Error Handling"]
  E --> F["Fallback Black Frame"]
  D --> G["Successful Frame"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vati_screenshare.py</strong><dd><code>Enhanced screen capture with robust error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vati_screenshare.py

<ul><li>Add logging and error handling throughout screen capture<br> <li> Implement monitor index validation with fallback logic<br> <li> Add runtime setters for monitor and region configuration<br> <li> Use executor for frame grabbing and proper resource cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/VatiVision_Pro/pull/3/files#diff-ad7d8041f50dafe0d21ef099a2eceefe9890d45e662b69f54d410a9232bff22f">+103/-18</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

