### PR TITLE
Localize role selector labels to Hungarian

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -378,7 +378,9 @@ class Main(QtWidgets.QMainWindow):
         v = QtWidgets.QVBoxLayout(panel)
 
         row = QtWidgets.QHBoxLayout()
-        self.role_combo = QtWidgets.QComboBox(); self.role_combo.addItems(["sender","receiver"])
+        self.role_combo = QtWidgets.QComboBox()
+        self.role_combo.addItem("Küldő", userData="sender")
+        self.role_combo.addItem("Fogadó", userData="receiver")
         row.addWidget(QtWidgets.QLabel("Szerep:")); row.addWidget(self.role_combo); row.addStretch(1)
         v.addLayout(row)
 
@@ -448,7 +450,8 @@ class Main(QtWidgets.QMainWindow):
     @QtCore.Slot()
     def on_start(self):
         if self.core: return
-        role = self.role_combo.currentText(); prefer = self.chk_relay.isChecked()
+        role = self.role_combo.currentData() or self.role_combo.currentText()
+        prefer = self.chk_relay.isChecked()
         self.core = Core(role=role, prefer_relay=prefer)
         self.core.status.connect(self.status.setText)
         self.core.log.connect(self.log.appendPlainText)


### PR DESCRIPTION
### **User description**
## Summary
- update the role selector options to display Hungarian labels for sender and receiver
- continue passing the expected internal role identifiers when starting the connection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93f9a3df083278676e48f0fc72386


___

### **PR Type**
Enhancement


___

### **Description**
- Localize role selector labels to Hungarian

- Maintain internal role identifiers for functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Role ComboBox"] --> B["Hungarian Labels"]
  B --> C["Küldő (Sender)"]
  B --> D["Fogadó (Receiver)"]
  E["Internal Logic"] --> F["Uses userData/currentText"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vativision_pro_client.py</strong><dd><code>Localize role selector to Hungarian</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vativision_pro_client.py

<ul><li>Replace hardcoded English role labels with Hungarian equivalents<br> <li> Add userData to combo box items to preserve internal identifiers<br> <li> Update role retrieval logic to use userData with fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/VatiVision_Pro/pull/7/files#diff-b05745b84314d772001d12bbae8e69b4370442c4b21ff93c4af7fea6b6a16451">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

