### PR TITLE
Localize role names in role selector

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -462,7 +462,9 @@ class Main(QtWidgets.QMainWindow):
         v = QtWidgets.QVBoxLayout(panel)
 
         row = QtWidgets.QHBoxLayout()
-        self.role_combo = QtWidgets.QComboBox(); self.role_combo.addItems(["sender","receiver"])
+        self.role_combo = QtWidgets.QComboBox()
+        self.role_combo.addItem("Küldő", "sender")
+        self.role_combo.addItem("Fogadó", "receiver")
         row.addWidget(QtWidgets.QLabel("Szerep:")); row.addWidget(self.role_combo); row.addStretch(1)
         v.addLayout(row)
 
@@ -540,9 +542,11 @@ class Main(QtWidgets.QMainWindow):
     @QtCore.Slot()
     def on_start(self):
         if self.core: return
-        role = self.role_combo.currentText(); prefer = self.chk_relay.isChecked()
-        self.log_ui_message(f"Kapcsolat indítása szerep={role}, prefer_relay={prefer}")
-        self.core = Core(role=role, prefer_relay=prefer)
+        role_label = self.role_combo.currentText()
+        role_value = self.role_combo.currentData() or "sender"
+        prefer = self.chk_relay.isChecked()
+        self.log_ui_message(f"Kapcsolat indítása szerep={role_label}, prefer_relay={prefer}")
+        self.core = Core(role=role_value, prefer_relay=prefer)
         self.core.status.connect(self.status.setText)
         self.core.log.connect(self.append_log_message)
         self.core.msg_in.connect(self.inbox.appendPlainText)


### PR DESCRIPTION
### **User description**
## Summary
- show the role selector entries using the Hungarian labels "Küldő" and "Fogadó"
- map the displayed labels back to the expected internal sender/receiver values when starting a session

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d940739984832788502ac1545c5248


___

### **PR Type**
Enhancement


___

### **Description**
- Localize role selector to display Hungarian labels

- Map Hungarian labels to internal English values

- Improve user experience with native language interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Role Combo Box"] --> B["Display Hungarian Labels"]
  B --> C["Küldő (Sender)"]
  B --> D["Fogadó (Receiver)"]
  C --> E["Map to 'sender'"]
  D --> F["Map to 'receiver'"]
  E --> G["Core System"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vativision_pro_client.py</strong><dd><code>Localize role selector with Hungarian labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vativision_pro_client.py

<ul><li>Replace simple text items with data-paired items in role combo box<br> <li> Add Hungarian labels "Küldő" and "Fogadó" with English data values<br> <li> Update role selection logic to use <code>currentData()</code> for internal values<br> <li> Maintain display of Hungarian labels in log messages</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/VatiVision_Pro/pull/9/files#diff-b05745b84314d772001d12bbae8e69b4370442c4b21ff93c4af7fea6b6a16451">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

