### PR TITLE
Add automatic pong response for ping data channel

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -227,6 +227,17 @@ class Core(QtCore.QObject):
 
     def _handle_message(self, m):
         if isinstance(m, str):
+            if m == "ping":
+                self.msg_in.emit("Ping érkezett ✅")
+                if self.channel and self.channel.readyState == "open":
+                    try:
+                        self.channel.send("pong")
+                    except Exception as exc:
+                        self._emit_log(f"Ping visszajelzés küldési hiba: {exc}", logging.WARNING)
+                return
+            if m == "pong":
+                self.msg_in.emit("Pong visszaigazolás megérkezett ✅")
+                return
             if m.startswith("BW_BEGIN"):
                 self._bw_recv_active = True
                 self._bw_recv_bytes  = 0


### PR DESCRIPTION
## Summary
- reply to incoming ping messages by emitting a confirmation in the UI and sending a pong acknowledgement
- surface pong acknowledgements in the message log and warn if replying fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d94146bab08327be5a413892201e11