### PR TITLE
Add top-left title label to main window

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -648,7 +648,20 @@ class Main(QtWidgets.QMainWindow):
         self.ui_logger = logging.getLogger(f"{__name__}.UI")
 
         central = QtWidgets.QWidget(); self.setCentralWidget(central)
-        root = QtWidgets.QHBoxLayout(central); root.setContentsMargins(12,12,12,12); root.setSpacing(12)
+
+        main_layout = QtWidgets.QVBoxLayout(central)
+        main_layout.setContentsMargins(12, 12, 12, 12)
+        main_layout.setSpacing(10)
+
+        title_label = QtWidgets.QLabel("VatiVision Pro")
+        title_label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        title_label.setStyleSheet("font-size: 20px; font-weight: 700;")
+        main_layout.addWidget(title_label, 0, QtCore.Qt.AlignLeft)
+
+        root = QtWidgets.QHBoxLayout()
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(12)
+        main_layout.addLayout(root, 1)
 
         side = QtWidgets.QFrame(); side.setFixedWidth(340)
         side.setStyleSheet(f"QFrame {{ background-color:{DARK_CARD}; border-radius:12px; }}")


### PR DESCRIPTION
## Summary
- refactor the main window layout to introduce a top-level vertical container
- add a prominent "VatiVision Pro" label aligned to the top-left corner of the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d977d6bab88327a7c4a04ee1662a05