### PR TITLE
Remove redundant top-left title label

### DIFF
--- a/vativision_pro_client.py
+++ b/vativision_pro_client.py
@@ -653,11 +653,6 @@ class Main(QtWidgets.QMainWindow):
         main_layout.setContentsMargins(12, 12, 12, 12)
         main_layout.setSpacing(10)
 
-        title_label = QtWidgets.QLabel("VatiVision Pro")
-        title_label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
-        title_label.setStyleSheet("font-size: 20px; font-weight: 700;")
-        main_layout.addWidget(title_label, 0, QtCore.Qt.AlignLeft)
-
         root = QtWidgets.QHBoxLayout()
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(12)


### PR DESCRIPTION
## Summary
- remove the extra standalone "VatiVision Pro" label from the main window layout so the header no longer repeats

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d979eb7d08832785a6781e1647f81b