### PR TITLE
Enable cursor capture in screen sharing

### DIFF
--- a/vati_screenshare.py
+++ b/vati_screenshare.py
@@ -130,7 +130,10 @@ class ScreenShareTrack(VideoStreamTrack):
                 "height": int(mon["height"]),
             }
 
-        raw = self._sct.grab(bbox)
+        try:
+            raw = self._sct.grab(bbox, include_cursor=True)
+        except TypeError:
+            raw = self._sct.grab(bbox)
         img = Image.frombytes("RGB", raw.size, raw.rgb)
         if self._size and raw.size != self._size:
             img = img.resize(self._size, Image.LANCZOS)


### PR DESCRIPTION
## Summary
- ensure the MSS screen captures include the mouse cursor when supported
- fall back to the previous behaviour if the MSS version does not support cursor capture

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97a05e62883279405020354fe48e2