### PR TITLE
Improve screen share frame pacing

### DIFF
--- a/vati_screenshare.py
+++ b/vati_screenshare.py
@@ -213,10 +213,15 @@ class ScreenShareTrack(VideoStreamTrack):
         fps = max(1, int(self._fps))
         period = 1.0 / float(fps)
         now = time.perf_counter()
-        wait = self._last_ts + period - now
+        if self._last_ts <= 0:
+            self._last_ts = now
+        target = self._last_ts + period
+        wait = target - now
         if wait > 0:
             await asyncio.sleep(wait)
-        self._last_ts = time.perf_counter()
+            self._last_ts = target
+        else:
+            self._last_ts = time.perf_counter()
 
         try:
             loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary
- adjust ScreenShareTrack timing logic to maintain the requested frame cadence
- initialize the frame scheduler on first use to avoid long frame intervals

## Testing
- python -m compileall vati_screenshare.py

------
https://chatgpt.com/codex/tasks/task_e_68da6d0b8a708327aabfceb2c1ffdd38