### PR TITLE
Fix stylesheet config import

### DIFF
--- a/vativision_pro/ui/style.py
+++ b/vativision_pro/ui/style.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .config import DARK_BG, DARK_CARD, DARK_ELEV, ACCENT, TEXT
+from ..config import DARK_BG, DARK_CARD, DARK_ELEV, ACCENT, TEXT
 
 def style():
     return f"""


### PR DESCRIPTION
## Summary
- correct the Qt stylesheet module to import theme colors from the main config package

## Testing
- python -m compileall vativision_pro/ui/style.py

------
https://chatgpt.com/codex/tasks/task_e_68da78ac7f3c8327b36d6520b5064773