### PR TITLE
Fix cursor overlay constants import

### DIFF
--- a/vativision_pro/ui/main_window.py
+++ b/vativision_pro/ui/main_window.py
@@ -21,6 +21,7 @@ from ..config import (
     ROOM_PIN,
     SIGNALING_WS,
 )
+from ..media.screenshare import CURSOR_MIN_SIZE, CURSOR_SCALE_RATIO
 from ..core import Core
 from ..media.audio import audio_playback_supported, audio_capture_supported
 from .style import style


### PR DESCRIPTION
## Summary
- import the cursor scaling constants in the main window module so the pointer overlay works without raising a NameError

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7a614b38832785077e8fdf343166