### PR TITLE
Ensure packaged builds ship and use program logo icon

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -28,6 +28,13 @@ class ScriptNotFoundError(FileNotFoundError):
     """Raised when the target script cannot be located."""
 
 
+def _format_add_data(source: Path, destination: str) -> str:
+    """Return a platform correct ``--add-data`` specification."""
+
+    separator = ";" if sys.platform.startswith("win") else ":"
+    return f"{source}{separator}{destination}"
+
+
 def _build_arguments(script: Path, *, icon: Path | None, name: str | None) -> List[str]:
     """Compose the argument list that will be passed to PyInstaller."""
 
@@ -38,6 +45,10 @@ def _build_arguments(script: Path, *, icon: Path | None, name: str | None) -> Li
 
     if name:
         args.extend(["--name", name])
+
+    logo_path = DEFAULT_ICON
+    if logo_path.exists():
+        args.extend(["--add-data", _format_add_data(logo_path, ".")])
 
     args.append(str(script))
     return args

--- a/vativision_pro/config.py
+++ b/vativision_pro/config.py
@@ -3,11 +3,37 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 
 from .utils import _resolve_documents_dir, _setup_file_logging
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+def _iter_project_roots() -> list[Path]:
+    """Return possible base directories for bundled assets.
+
+    When the application is packaged with PyInstaller the resources are
+    temporarily extracted either next to the executable or into the
+    ``_MEIPASS`` directory.  During development ``__file__`` still points to
+    the repository checkout.  We return every relevant candidate so that the
+    caller can select the first existing path.
+    """
+
+    roots = [Path(__file__).resolve().parent.parent]
+
+    if getattr(sys, "frozen", False):  # running from a packaged executable
+        executable_dir = Path(sys.executable).resolve().parent
+        if executable_dir not in roots:
+            roots.insert(0, executable_dir)
+
+        bundle_dir = Path(getattr(sys, "_MEIPASS", executable_dir))
+        if bundle_dir not in roots:
+            roots.insert(0, bundle_dir)
+
+    return roots
+
+
+PROJECT_ROOT = _iter_project_roots()[0]
 MEDIA_DIR = PROJECT_ROOT / "vativision_pro" / "media"
 
 SIGNALING_WS = "wss://vatib-vezerlo.duckdns.org/ws"
@@ -17,7 +43,18 @@ ROOM_PIN = "428913"
 STUN_URLS = ["stun:stun.l.google.com:19302"]
 
 APP_TITLE = "VatiVision Pro - UMKGL Solutions"
-APP_ICON_PATH = PROJECT_ROOT / "program_logo.png"
+def _resolve_app_icon_path() -> Path:
+    """Locate the bundled program logo regardless of the execution mode."""
+
+    for root in _iter_project_roots():
+        candidate = root / "program_logo.png"
+        if candidate.exists():
+            return candidate
+    # Fall back to the repository location; the file may simply be missing.
+    return Path(__file__).resolve().parent.parent / "program_logo.png"
+
+
+APP_ICON_PATH = _resolve_app_icon_path()
 CURSOR_IMAGE_PATH = MEDIA_DIR / "cursor.png"
 
 BW_SECONDS = 5.0


### PR DESCRIPTION
## Summary
- update the configuration so the application icon is resolved from PyInstaller bundle locations when frozen
- bundle `program_logo.png` with the PyInstaller executable to keep the tray and window icons available at runtime

## Testing
- python -m compileall vativision_pro

------
https://chatgpt.com/codex/tasks/task_e_68da7b9a3cc08327ba9804442a95b351