### PR TITLE
Fix remote pointer transparency and alignment

### DIFF
--- a/vativision_pro/ui/cursor_utils.py
+++ b/vativision_pro/ui/cursor_utils.py
@@ -1,0 +1,47 @@
+"""Helper utilities for preparing cursor graphics."""
+
+from __future__ import annotations
+
+from PySide6 import QtGui
+
+
+def _is_close(color: QtGui.QColor, reference: QtGui.QColor, tolerance: int) -> bool:
+    return (
+        abs(color.red() - reference.red()) <= tolerance
+        and abs(color.green() - reference.green()) <= tolerance
+        and abs(color.blue() - reference.blue()) <= tolerance
+    )
+
+
+def sanitize_cursor_pixmap(pixmap: QtGui.QPixmap, *, tolerance: int = 12) -> QtGui.QPixmap:
+    """Return a pixmap without opaque background or dark silhouettes."""
+
+    if pixmap.isNull():
+        return pixmap
+
+    image = pixmap.toImage().convertToFormat(QtGui.QImage.Format_ARGB32)
+    if image.isNull() or image.width() <= 0 or image.height() <= 0:
+        return pixmap
+
+    background = image.pixelColor(0, 0)
+    for y in range(image.height()):
+        for x in range(image.width()):
+            color = image.pixelColor(x, y)
+            if color.alpha() == 0:
+                continue
+
+            make_transparent = False
+            if _is_close(color, background, tolerance):
+                make_transparent = True
+            else:
+                if color.alpha() < 220 and max(color.red(), color.green(), color.blue()) < 40:
+                    make_transparent = True
+
+            if make_transparent:
+                color.setAlpha(0)
+                color.setRed(0)
+                color.setGreen(0)
+                color.setBlue(0)
+                image.setPixelColor(x, y, color)
+
+    return QtGui.QPixmap.fromImage(image)

--- a/vativision_pro/ui/main_window.py
+++ b/vativision_pro/ui/main_window.py
@@ -21,11 +21,17 @@ from ..config import (
     ROOM_PIN,
     SIGNALING_WS,
 )
-from ..media.screenshare import CURSOR_MIN_SIZE, CURSOR_SCALE_RATIO
+from ..media.screenshare import (
+    CURSOR_MIN_SIZE,
+    CURSOR_SCALE_RATIO,
+    CURSOR_OFFSET_X,
+    CURSOR_OFFSET_Y,
+)
 from ..core import Core
 from ..media.audio import audio_playback_supported, audio_capture_supported
 from .style import style
 from .widgets import AnimatedButton, VideoSurface, FullscreenViewer, ScreenPointerOverlay
+from .cursor_utils import sanitize_cursor_pixmap
 
 class Main(QtWidgets.QMainWindow):
     def __init__(self):
@@ -223,7 +229,9 @@ class Main(QtWidgets.QMainWindow):
         self.fullscreen_window: Optional[FullscreenViewer] = None
         self._last_pixmap: Optional[QtGui.QPixmap] = None
         if CURSOR_IMAGE_PATH.exists():
-            self._cursor_pixmap = QtGui.QPixmap(str(CURSOR_IMAGE_PATH))
+            self._cursor_pixmap = sanitize_cursor_pixmap(
+                QtGui.QPixmap(str(CURSOR_IMAGE_PATH))
+            )
         else:
             self._cursor_pixmap = QtGui.QPixmap()
         self._cursor_scaled: Optional[QtGui.QPixmap] = None
@@ -445,8 +453,8 @@ class Main(QtWidgets.QMainWindow):
         offset_x = max(0, (lw - pw) // 2)
         offset_y = max(0, (lh - ph) // 2)
         nx, ny = self._pointer_norm
-        x = offset_x + int(round(nx * pw))
-        y = offset_y + int(round(ny * ph))
+        x = offset_x + int(round(nx * pw + CURSOR_OFFSET_X))
+        y = offset_y + int(round(ny * ph + CURSOR_OFFSET_Y))
         ow = self.pointer_overlay.width()
         oh = self.pointer_overlay.height()
         x = max(0, min(x, lw - ow))


### PR DESCRIPTION
## Summary
- remove background artifacts from the pointer icon by sanitizing the image for both screen capture and Qt overlays
- reposition the pointer overlay 15 pixels left and 10 pixels above the click location across all views

## Testing
- python -m compileall vativision_pro

------
https://chatgpt.com/codex/tasks/task_e_68da827af1fc83278847bc97eee9591c