### PR TITLE
Add Boneca Ambalabu playback button

### DIFF
--- a/vativision_pro/config.py
+++ b/vativision_pro/config.py
@@ -35,6 +35,7 @@ def _iter_project_roots() -> list[Path]:
 
 PROJECT_ROOT = _iter_project_roots()[0]
 MEDIA_DIR = PROJECT_ROOT / "vativision_pro" / "media"
+BONECA_AMBALABU_AUDIO = MEDIA_DIR / "boneca ambalabu.mp3"
 
 SIGNALING_WS = "wss://vatib-vezerlo.duckdns.org/ws"
 TURN_HOST = "vatib-vezerlo.duckdns.org"
@@ -86,6 +87,7 @@ __all__ = [
     "APP_TITLE",
     "APP_ICON_PATH",
     "CURSOR_IMAGE_PATH",
+    "BONECA_AMBALABU_AUDIO",
     "BW_SECONDS",
     "BW_CHUNK",
     "BW_MAX_BUF",


### PR DESCRIPTION
## Summary
- add a config constant for the bundled Boneca Ambalabu audio track
- add a green "Boneca Ambalabu" control button that plays the mp3 from the media folder via QMediaPlayer

## Testing
- python -m compileall vativision_pro

------
https://chatgpt.com/codex/tasks/task_e_68da964d559c832792394834ec8b72cd