### PR TITLE
Ensure shared sessions display host cursor

### DIFF
--- a/vativision_pro/core.py
+++ b/vativision_pro/core.py
@@ -1001,3 +1001,12 @@ class Core(QtCore.QObject):
         if self._share_track:
             return self._share_track.get_last_capture_bbox()
         return None
+
+    def update_local_pointer(self, norm_x: float, norm_y: float, visible: bool) -> None:
+        track = self._share_track
+        if not track:
+            return
+        if visible:
+            track.set_local_pointer(norm_x, norm_y)
+        else:
+            track.clear_local_pointer()


### PR DESCRIPTION
## Summary
- add a Qt-based polling timer to track the sender cursor during screen sharing and feed it into the media pipeline
- render both local and remote pointer overlays inside the encoded screen share stream
- expose a core helper to toggle the local pointer while keeping existing pointer-sharing features working

## Testing
- python -m compileall vativision_pro

------
https://chatgpt.com/codex/tasks/task_e_68daa08e98dc83278ed54adab4b83642