### PR TITLE
Fix pointer overlay transparency artifacts

### DIFF
--- a/vativision_pro/ui/main_window.py
+++ b/vativision_pro/ui/main_window.py
@@ -187,6 +187,9 @@ class Main(QtWidgets.QMainWindow):
 
         self.pointer_overlay = QtWidgets.QLabel(self.video_label)
         self.pointer_overlay.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
+        self.pointer_overlay.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.pointer_overlay.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.pointer_overlay.setStyleSheet("background: transparent;")
         self.pointer_overlay.hide()
 
         controls_row = QtWidgets.QHBoxLayout()

--- a/vativision_pro/ui/widgets.py
+++ b/vativision_pro/ui/widgets.py
@@ -116,6 +116,9 @@ class FullscreenViewer(QtWidgets.QWidget):
 
         self.pointer_overlay = QtWidgets.QLabel(self.label)
         self.pointer_overlay.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
+        self.pointer_overlay.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.pointer_overlay.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.pointer_overlay.setStyleSheet("background: transparent;")
         self.pointer_overlay.hide()
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
@@ -261,6 +264,9 @@ class ScreenPointerOverlay(QtWidgets.QWidget):
 
         self.label = QtWidgets.QLabel(self)
         self.label.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
+        self.label.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.label.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.label.setStyleSheet("background: transparent;")
         self.label.hide()
 
     def set_cursor_source(self, pixmap: QtGui.QPixmap) -> None:


### PR DESCRIPTION
## Summary
- ensure all pointer overlay labels use translucent, backgroundless windows
- align fullscreen and external overlay labels with the same transparent styling to avoid cursor boxes

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68daa3af8704832788ba204139bfa30e