### PR TITLE
Display actual Windows cursor in screen share

### DIFF
--- a/vativision_pro/ui/cursor_utils.py
+++ b/vativision_pro/ui/cursor_utils.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+import sys
+from typing import Optional, Tuple
+
 from PySide6 import QtGui
+
+logger = logging.getLogger(__name__)
 
 
 def _is_close(color: QtGui.QColor, reference: QtGui.QColor, tolerance: int) -> bool:
@@ -45,3 +51,63 @@ def sanitize_cursor_pixmap(pixmap: QtGui.QPixmap, *, tolerance: int = 12) -> QtG
                 image.setPixelColor(x, y, color)
 
     return QtGui.QPixmap.fromImage(image)
+
+
+def get_system_cursor_pixmap() -> Tuple[Optional[QtGui.QPixmap], Optional[int]]:
+    """Return the currently active system cursor pixmap on Windows.
+
+    The function returns a tuple containing the sanitized pixmap (if one could be
+    obtained) and the numeric value of the cursor handle.  The handle value can be
+    used by callers to detect shape changes without comparing pixmaps directly.
+    On non-Windows platforms the function simply returns ``(None, None)``.
+    """
+
+    if not sys.platform.startswith("win"):
+        return None, None
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        class POINT(ctypes.Structure):
+            _fields_ = [("x", wintypes.LONG), ("y", wintypes.LONG)]
+
+        class CURSORINFO(ctypes.Structure):
+            _fields_ = [
+                ("cbSize", wintypes.DWORD),
+                ("flags", wintypes.DWORD),
+                ("hCursor", wintypes.HCURSOR),
+                ("ptScreenPos", POINT),
+            ]
+
+        CURSOR_SHOWING = 0x00000001
+
+        user32 = ctypes.windll.user32
+        info = CURSORINFO()
+        info.cbSize = ctypes.sizeof(CURSORINFO)
+
+        if not user32.GetCursorInfo(ctypes.byref(info)):
+            return None, None
+
+        handle_value = ctypes.cast(info.hCursor, ctypes.c_void_p).value or 0
+        handle_int = int(handle_value)
+
+        if not (info.flags & CURSOR_SHOWING):
+            return None, handle_int
+
+        hicon = user32.CopyIcon(info.hCursor)
+        if not hicon:
+            return None, handle_int
+
+        try:
+            pixmap = QtGui.QPixmap.fromWinHICON(hicon)
+        finally:
+            user32.DestroyIcon(hicon)
+
+        if pixmap.isNull():
+            return None, handle_int
+
+        return sanitize_cursor_pixmap(pixmap), handle_int
+    except Exception:  # pragma: no cover - platform specific defensive guard
+        logger.exception("Failed to query system cursor pixmap.")
+        return None, None

--- a/vativision_pro/ui/main_window.py
+++ b/vativision_pro/ui/main_window.py
@@ -32,7 +32,7 @@ from ..core import Core
 from ..media.audio import audio_playback_supported, audio_capture_supported
 from .style import style
 from .widgets import AnimatedButton, VideoSurface, FullscreenViewer, ScreenPointerOverlay
-from .cursor_utils import sanitize_cursor_pixmap
+from .cursor_utils import sanitize_cursor_pixmap, get_system_cursor_pixmap
 
 class Main(QtWidgets.QMainWindow):
     def __init__(self):
@@ -264,21 +264,20 @@ class Main(QtWidgets.QMainWindow):
 
         self.fullscreen_window: Optional[FullscreenViewer] = None
         self._last_pixmap: Optional[QtGui.QPixmap] = None
-        if CURSOR_IMAGE_PATH.exists():
-            self._cursor_pixmap = sanitize_cursor_pixmap(
-                QtGui.QPixmap(str(CURSOR_IMAGE_PATH))
-            )
-        else:
-            self._cursor_pixmap = QtGui.QPixmap()
+        self._cursor_pixmap = QtGui.QPixmap()
+        self._fallback_cursor_pixmap = QtGui.QPixmap()
         self._cursor_scaled: Optional[QtGui.QPixmap] = None
         self._cursor_scaled_width: int = 0
+        self._cursor_handle: Optional[int] = None
+        self._load_default_cursor_pixmap()
         self._pointer_timer = QtCore.QTimer(self)
         self._pointer_timer.setSingleShot(True)
         self._pointer_timer.timeout.connect(self.on_pointer_timeout)
         self._pointer_norm: Optional[Tuple[float, float]] = None
         self._pointer_local = False
         self._screen_pointer_overlay = ScreenPointerOverlay()
-        self._screen_pointer_overlay.set_cursor_source(self._cursor_pixmap)
+        self._apply_cursor_pixmap(self._cursor_pixmap)
+        self._try_update_system_cursor_pixmap(force=True)
         self._cursor_monitor_timer = QtCore.QTimer(self)
         self._cursor_monitor_timer.setInterval(66)
         self._cursor_monitor_timer.timeout.connect(self._poll_local_pointer)
@@ -288,6 +287,60 @@ class Main(QtWidgets.QMainWindow):
         self._loading_settings = False
         self._restore_settings()
         self._update_role_ui(self.role_combo.currentData() or "sender")
+
+    def _load_default_cursor_pixmap(self) -> None:
+        """Load the bundled fallback cursor pixmap."""
+
+        pixmap = QtGui.QPixmap()
+        if CURSOR_IMAGE_PATH.exists():
+            pixmap = sanitize_cursor_pixmap(QtGui.QPixmap(str(CURSOR_IMAGE_PATH)))
+        if pixmap.isNull():
+            fallback_arrow = QtGui.QCursor(QtCore.Qt.ArrowCursor).pixmap()
+            if not fallback_arrow.isNull():
+                pixmap = sanitize_cursor_pixmap(fallback_arrow)
+        self._fallback_cursor_pixmap = pixmap
+        self._cursor_pixmap = pixmap
+        self._cursor_scaled = None
+        self._cursor_scaled_width = 0
+
+    def _apply_cursor_pixmap(self, pixmap: QtGui.QPixmap) -> None:
+        """Update every pointer overlay to use the provided pixmap."""
+
+        if pixmap and not pixmap.isNull():
+            pixmap = sanitize_cursor_pixmap(pixmap)
+        else:
+            pixmap = QtGui.QPixmap()
+
+        self._cursor_pixmap = pixmap
+        self._cursor_scaled = None
+        self._cursor_scaled_width = 0
+
+        if hasattr(self, "_screen_pointer_overlay"):
+            self._screen_pointer_overlay.set_cursor_source(self._cursor_pixmap)
+        if self.fullscreen_window:
+            self.fullscreen_window.set_cursor_source(self._cursor_pixmap)
+        if self.pointer_overlay.isVisible() and self._pointer_norm is not None:
+            nx, ny = self._pointer_norm
+            self._show_pointer_overlay(nx, ny, local=self._pointer_local)
+
+    def _try_update_system_cursor_pixmap(self, *, force: bool = False) -> None:
+        """Refresh the cursor pixmap from the operating system if available."""
+
+        pixmap, handle = get_system_cursor_pixmap()
+        if handle is None:
+            if force and self._cursor_pixmap.isNull() and not self._fallback_cursor_pixmap.isNull():
+                self._apply_cursor_pixmap(self._fallback_cursor_pixmap)
+            return
+
+        if not force and handle == self._cursor_handle:
+            return
+
+        self._cursor_handle = handle
+
+        if pixmap and not pixmap.isNull():
+            self._apply_cursor_pixmap(pixmap)
+        elif force and not self._fallback_cursor_pixmap.isNull():
+            self._apply_cursor_pixmap(self._fallback_cursor_pixmap)
 
     @QtCore.Slot(str)
     def append_log_message(self, message: str) -> None:
@@ -334,6 +387,7 @@ class Main(QtWidgets.QMainWindow):
         if not self.core or self.core.role != "sender":
             self._stop_local_pointer_monitor()
             return
+        self._try_update_system_cursor_pixmap()
         bbox = self.core.get_capture_geometry()
         if not bbox:
             if self._cursor_monitor_last_visible:


### PR DESCRIPTION
## Summary
- retrieve the sender's current Windows cursor via WinAPI and expose it through a new utility
- refresh all pointer overlays to use the live system cursor with a bundled fallback when needed

## Testing
- python -m compileall vativision_pro/ui/cursor_utils.py vativision_pro/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68daa376bf1c83279123a9f22ed03513