### PR TITLE
Force mono audio capture

### DIFF
--- a/vativision_pro/media/audio.py
+++ b/vativision_pro/media/audio.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 _SAMPLE_RATE = 48_000
-_CHANNELS = 2
+_CHANNELS = 1
 _BLOCK_DURATION = 0.02  # 20 ms
 
 


### PR DESCRIPTION
## Summary
- change the audio capture channel count constant to 1 so the app uses mono input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa881b4cc8327b9f1c28436f3e57c