### PR TITLE
Add Windows cursor fallback handling for screen sharing

### DIFF
--- a/vativision_pro/core.py
+++ b/vativision_pro/core.py
@@ -1028,11 +1028,18 @@ class Core(QtCore.QObject):
             return self._share_track.get_last_capture_bbox()
         return None
 
-    def update_local_pointer(self, norm_x: float, norm_y: float, visible: bool) -> None:
+    def update_local_pointer(
+        self,
+        norm_x: float,
+        norm_y: float,
+        visible: bool,
+        shape: Optional[str] = None,
+        cursor_handle: Optional[int] = None,
+    ) -> None:
         track = self._share_track
         if not track:
             return
         if visible:
-            track.set_local_pointer(norm_x, norm_y)
+            track.set_local_pointer(norm_x, norm_y, shape=shape, cursor_handle=cursor_handle)
         else:
             track.clear_local_pointer()

--- a/vativision_pro/media/screenshare.py
+++ b/vativision_pro/media/screenshare.py
@@ -23,6 +23,12 @@ RESOLUTIONS = {
     "1080p (1920×1080)":(1920, 1080),
 }
 
+FALLBACK_CURSOR_FILES = {
+    "arrow": "Aero Arrow.cur",
+    "ibeam": "Aero iBeam.cur",
+    "link": "Aero Link.cur",
+}
+
 # A kurzor legyen ~15%-kal kisebb, ezért csökkentjük a skálázási arányt.
 CURSOR_SCALE_RATIO = 0.02125
 CURSOR_MIN_SIZE = 12
@@ -62,13 +68,17 @@ class ScreenShareTrack(VideoStreamTrack):
         self._capture_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="vati-screenshare"
         )
-        self._cursor_image = None
-        self._cursor_cache = None
-        self._cursor_cache_size: Optional[Tuple[int, int]] = None
+        self._cursor_images: dict[str, Image.Image] = {}
+        self._cursor_cache: dict[Tuple[str, Tuple[int, int]], Image.Image] = {}
+        self._default_cursor_shape: Optional[str] = None
+        self._system_cursor_handle: Optional[int] = None
+        self._system_cursor_failed = False
         self._pointer_visible = False
         self._pointer_norm: Tuple[float, float] = (0.0, 0.0)
+        self._remote_pointer_shape: Optional[str] = None
         self._local_pointer_visible = False
         self._local_pointer_norm: Tuple[float, float] = (0.0, 0.0)
+        self._local_pointer_shape: Optional[str] = None
         self._pointer_lock = threading.Lock()
         self._last_capture_bbox: Optional[Tuple[int, int, int, int]] = None
 
@@ -76,40 +86,41 @@ class ScreenShareTrack(VideoStreamTrack):
         self._init_capture()
 
     def _load_cursor(self) -> None:
+        self._cursor_images.clear()
+        self._cursor_cache.clear()
+        self._default_cursor_shape = None
+        self._system_cursor_handle = None
+        self._system_cursor_failed = False
+
+        self._load_fallback_cursors()
+
         if sys.platform.startswith("win"):
             try:
                 from ..ui.cursor_utils import get_system_cursor_pixmap
 
-                pixmap, _ = get_system_cursor_pixmap()
+                pixmap, handle, shape = get_system_cursor_pixmap()
             except Exception:  # pragma: no cover - defensive guard
                 logger.exception("Nem sikerült lekérni a rendszer kurzorát.")
                 pixmap = None
+                handle = None
+                shape = None
+
+            if handle is not None:
+                self._system_cursor_handle = handle
 
             if pixmap and not pixmap.isNull():
-                image = pixmap.toImage().convertToFormat(QtGui.QImage.Format_RGBA8888)
-                if not image.isNull() and image.width() > 0 and image.height() > 0:
-                    ptr = image.bits()
-                    ptr.setsize(image.width() * image.height() * 4)
-                    arr = np.frombuffer(ptr, np.uint8).reshape((image.height(), image.width(), 4))
-                    pil_cursor = Image.fromarray(arr, mode="RGBA")
-                    self._cursor_image = self._sanitize_cursor_transparency(pil_cursor)
-                    self._cursor_cache = None
-                    self._cursor_cache_size = None
-                    return
+                pil_cursor = self._convert_qpixmap_to_pil(pixmap)
+                if pil_cursor:
+                    self._cursor_images["system"] = self._sanitize_cursor_transparency(pil_cursor)
+                    self._default_cursor_shape = "system"
+            elif shape and shape in self._cursor_images and self._default_cursor_shape is None:
+                self._default_cursor_shape = shape
 
-        cursor_path = Path(__file__).resolve().parent / "cursor.png"
-        if not cursor_path.exists():
-            logger.warning("A kurzor ikon (%s) nem található.", cursor_path)
-            return
-        try:
-            loaded = Image.open(cursor_path).convert("RGBA")
-            self._cursor_image = self._sanitize_cursor_transparency(loaded)
-        except Exception as exc:
-            logger.exception("Nem sikerült betölteni a kurzor ikont: %s", exc)
-            self._cursor_image = None
-            return
-        self._cursor_cache = None
-        self._cursor_cache_size = None
+        if self._default_cursor_shape is None:
+            if "arrow" in self._cursor_images:
+                self._default_cursor_shape = "arrow"
+            elif self._cursor_images:
+                self._default_cursor_shape = next(iter(self._cursor_images))
 
     @staticmethod
     def _sanitize_cursor_transparency(img: Image.Image) -> Image.Image:
@@ -137,6 +148,97 @@ class ScreenShareTrack(VideoStreamTrack):
         arr[mask, :3] = 0
         arr[mask, 3] = 0
         return Image.fromarray(arr, mode="RGBA")
+
+    def _load_fallback_cursors(self) -> None:
+        media_dir = Path(__file__).resolve().parent
+
+        for shape, filename in FALLBACK_CURSOR_FILES.items():
+            candidate = media_dir / filename
+            if not candidate.exists():
+                continue
+            try:
+                loaded = Image.open(candidate).convert("RGBA")
+            except Exception as exc:  # pragma: no cover - best effort load
+                logger.debug("Nem sikerült betölteni a %s kurzort: %s", candidate, exc)
+                continue
+            self._cursor_images[shape] = self._sanitize_cursor_transparency(loaded)
+
+        if "arrow" not in self._cursor_images:
+            legacy_cursor = media_dir / "cursor.png"
+            if legacy_cursor.exists():
+                try:
+                    loaded = Image.open(legacy_cursor).convert("RGBA")
+                except Exception:
+                    pass
+                else:
+                    self._cursor_images["arrow"] = self._sanitize_cursor_transparency(loaded)
+
+    @staticmethod
+    def _convert_qpixmap_to_pil(pixmap: QtGui.QPixmap) -> Optional[Image.Image]:
+        if not pixmap or pixmap.isNull():
+            return None
+        image = pixmap.toImage().convertToFormat(QtGui.QImage.Format_RGBA8888)
+        if image.isNull() or image.width() <= 0 or image.height() <= 0:
+            return None
+        ptr = image.bits()
+        ptr.setsize(image.width() * image.height() * 4)
+        arr = np.frombuffer(ptr, np.uint8).reshape((image.height(), image.width(), 4))
+        return Image.fromarray(arr, mode="RGBA")
+
+    def _purge_cursor_cache_for(self, shape: str) -> None:
+        to_remove = [key for key in self._cursor_cache if key[0] == shape]
+        for key in to_remove:
+            self._cursor_cache.pop(key, None)
+
+    def _ensure_system_cursor(self, cursor_handle: Optional[int]) -> None:
+        if not sys.platform.startswith("win"):
+            return
+        if cursor_handle is None:
+            return
+        if self._system_cursor_handle == cursor_handle:
+            if "system" in self._cursor_images or self._system_cursor_failed:
+                return
+
+        try:
+            from ..ui.cursor_utils import get_system_cursor_pixmap
+        except Exception:  # pragma: no cover - defensive guard
+            return
+
+        pixmap, handle, _shape = get_system_cursor_pixmap()
+        if handle is None:
+            self._system_cursor_failed = True
+            return
+
+        self._system_cursor_handle = handle
+
+        if pixmap and not pixmap.isNull():
+            pil_cursor = self._convert_qpixmap_to_pil(pixmap)
+            if pil_cursor:
+                self._cursor_images["system"] = self._sanitize_cursor_transparency(pil_cursor)
+                self._purge_cursor_cache_for("system")
+                self._default_cursor_shape = "system"
+                self._system_cursor_failed = False
+                return
+
+        self._system_cursor_failed = True
+
+    def _resolve_cursor_shape(self, requested: Optional[str]) -> Optional[str]:
+        if requested and requested in self._cursor_images:
+            return requested
+        if requested and requested != "arrow" and "arrow" in self._cursor_images:
+            return "arrow"
+        if "arrow" in self._cursor_images:
+            return "arrow"
+        if self._default_cursor_shape and self._default_cursor_shape in self._cursor_images:
+            return self._default_cursor_shape
+        if self._cursor_images:
+            return next(iter(self._cursor_images))
+        return None
+
+    def _select_local_shape(self, requested: Optional[str]) -> Optional[str]:
+        if "system" in self._cursor_images:
+            return "system"
+        return self._resolve_cursor_shape(requested)
 
     def set_size(self, width: int, height: int):
         self._size = (int(width), int(height))
@@ -233,65 +335,97 @@ class ScreenShareTrack(VideoStreamTrack):
             img = img.convert("RGB")
         return VideoFrame.from_image(img)
 
-    def _get_cursor_for_size(self, frame_size: Tuple[int, int]):
-        if not self._cursor_image:
+    def _get_cursor_for_size(
+        self, frame_size: Tuple[int, int], shape: Optional[str]
+    ) -> Optional[Image.Image]:
+        key = self._resolve_cursor_shape(shape)
+        if not key:
+            return None
+        base = self._cursor_images.get(key)
+        if base is None:
             return None
         width, height = frame_size
         if width <= 0 or height <= 0:
             return None
-        base = self._cursor_image
+        if base.width <= 0 or base.height <= 0:
+            return None
         target_width = min(base.width, max(CURSOR_MIN_SIZE, int(width * CURSOR_SCALE_RATIO)))
-        aspect = base.width / base.height if base.height else 1.0
+        if target_width <= 0:
+            return None
+        aspect = base.width / base.height
         target_height = min(base.height, max(CURSOR_MIN_SIZE, int(target_width / aspect)))
+        if target_height <= 0:
+            return None
         size = (target_width, target_height)
-        if self._cursor_cache is None or self._cursor_cache_size != size:
-            self._cursor_cache = base.resize(size, Image.LANCZOS)
-            self._cursor_cache_size = size
-        return self._cursor_cache
+        cache_key = (key, size)
+        cached = self._cursor_cache.get(cache_key)
+        if cached is None:
+            cached = base.resize(size, Image.LANCZOS)
+            self._cursor_cache[cache_key] = cached
+        return cached
 
     def _apply_pointer_overlay(self, img: Image.Image) -> Image.Image:
-        cursor = self._get_cursor_for_size(img.size)
-        if cursor is None:
-            return img
         with self._pointer_lock:
             pointer_states = []
             if self._local_pointer_visible:
-                pointer_states.append(self._local_pointer_norm)
+                pointer_states.append((self._local_pointer_norm, self._local_pointer_shape))
             if self._pointer_visible:
-                pointer_states.append(self._pointer_norm)
+                pointer_states.append((self._pointer_norm, self._remote_pointer_shape))
+
         if not pointer_states:
             return img
+
         width, height = img.size
-        cw, ch = cursor.size
         base = img.convert("RGBA")
-        for norm_x, norm_y in pointer_states:
+
+        for (norm_x, norm_y), shape in pointer_states:
+            cursor = self._get_cursor_for_size((width, height), shape)
+            if cursor is None:
+                continue
+            cw, ch = cursor.size
             x = int(round(norm_x * width + CURSOR_OFFSET_X))
             y = int(round(norm_y * height + CURSOR_OFFSET_Y))
             x = max(0, min(x, max(0, width - cw)))
             y = max(0, min(y, max(0, height - ch)))
             base.paste(cursor, (x, y), cursor)
+
         return base
 
     def set_remote_pointer(self, norm_x: float, norm_y: float) -> None:
         with self._pointer_lock:
             self._pointer_visible = True
-            self._pointer_norm = (float(max(0.0, min(1.0, norm_x))), float(max(0.0, min(1.0, norm_y))))
+            self._pointer_norm = (
+                float(max(0.0, min(1.0, norm_x))),
+                float(max(0.0, min(1.0, norm_y))),
+            )
+            self._remote_pointer_shape = None
 
     def clear_remote_pointer(self) -> None:
         with self._pointer_lock:
             self._pointer_visible = False
+            self._remote_pointer_shape = None
 
-    def set_local_pointer(self, norm_x: float, norm_y: float) -> None:
+    def set_local_pointer(
+        self,
+        norm_x: float,
+        norm_y: float,
+        *,
+        shape: Optional[str] = None,
+        cursor_handle: Optional[int] = None,
+    ) -> None:
+        self._ensure_system_cursor(cursor_handle)
         with self._pointer_lock:
             self._local_pointer_visible = True
             self._local_pointer_norm = (
                 float(max(0.0, min(1.0, norm_x))),
                 float(max(0.0, min(1.0, norm_y))),
             )
+            self._local_pointer_shape = self._select_local_shape(shape)
 
     def clear_local_pointer(self) -> None:
         with self._pointer_lock:
             self._local_pointer_visible = False
+            self._local_pointer_shape = None
 
     def get_last_capture_bbox(self) -> Optional[Tuple[int, int, int, int]]:
         return self._last_capture_bbox

--- a/vativision_pro/ui/cursor_utils.py
+++ b/vativision_pro/ui/cursor_utils.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from PySide6 import QtGui
 
 logger = logging.getLogger(__name__)
+
+
+CursorShape = Optional[str]
+_STANDARD_CURSOR_HANDLE_CACHE: Dict[int, Optional[int]] = {}
 
 
 def _is_close(color: QtGui.QColor, reference: QtGui.QColor, tolerance: int) -> bool:
@@ -53,17 +57,18 @@ def sanitize_cursor_pixmap(pixmap: QtGui.QPixmap, *, tolerance: int = 12) -> QtG
     return QtGui.QPixmap.fromImage(image)
 
 
-def get_system_cursor_pixmap() -> Tuple[Optional[QtGui.QPixmap], Optional[int]]:
-    """Return the currently active system cursor pixmap on Windows.
+def get_system_cursor_pixmap() -> Tuple[Optional[QtGui.QPixmap], Optional[int], CursorShape]:
+    """Return the current system cursor pixmap, handle and shape on Windows.
 
     The function returns a tuple containing the sanitized pixmap (if one could be
-    obtained) and the numeric value of the cursor handle.  The handle value can be
-    used by callers to detect shape changes without comparing pixmaps directly.
-    On non-Windows platforms the function simply returns ``(None, None)``.
+    obtained), the numeric value of the cursor handle, and a symbolic cursor
+    shape identifier.  When the cursor matches one of the standard Windows
+    cursors we resolve the handle to ``"arrow"``, ``"ibeam"`` or ``"link"``.
+    On non-Windows platforms the function simply returns ``(None, None, None)``.
     """
 
     if not sys.platform.startswith("win"):
-        return None, None
+        return None, None, None
 
     try:
         import ctypes
@@ -85,21 +90,31 @@ def get_system_cursor_pixmap() -> Tuple[Optional[QtGui.QPixmap], Optional[int]]:
         CURSOR_SHOWING = 0x00000001
 
         user32 = ctypes.windll.user32
+        user32.GetCursorInfo.argtypes = [ctypes.POINTER(CURSORINFO)]
+        user32.GetCursorInfo.restype = wintypes.BOOL
+        user32.CopyIcon.argtypes = [HCURSOR]
+        user32.CopyIcon.restype = ctypes.c_void_p
+        user32.DestroyIcon.argtypes = [HCURSOR]
+        user32.DestroyIcon.restype = wintypes.BOOL
+        user32.LoadCursorW.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        user32.LoadCursorW.restype = ctypes.c_void_p
+
         info = CURSORINFO()
         info.cbSize = ctypes.sizeof(CURSORINFO)
 
         if not user32.GetCursorInfo(ctypes.byref(info)):
-            return None, None
+            return None, None, None
 
         handle_value = ctypes.cast(info.hCursor, ctypes.c_void_p).value or 0
         handle_int = int(handle_value)
+        shape = _detect_cursor_shape(user32, handle_int)
 
         if not (info.flags & CURSOR_SHOWING):
-            return None, handle_int
+            return None, handle_int, shape
 
         hicon = user32.CopyIcon(info.hCursor)
         if not hicon:
-            return None, handle_int
+            return None, handle_int, shape
 
         try:
             pixmap = QtGui.QPixmap.fromWinHICON(hicon)
@@ -107,9 +122,60 @@ def get_system_cursor_pixmap() -> Tuple[Optional[QtGui.QPixmap], Optional[int]]:
             user32.DestroyIcon(hicon)
 
         if pixmap.isNull():
-            return None, handle_int
+            return None, handle_int, shape
 
-        return sanitize_cursor_pixmap(pixmap), handle_int
+        return sanitize_cursor_pixmap(pixmap), handle_int, shape
     except Exception:  # pragma: no cover - platform specific defensive guard
         logger.exception("Failed to query system cursor pixmap.")
-        return None, None
+        return None, None, None
+
+
+def _load_standard_cursor_handle(user32, resource_id: int) -> Optional[int]:
+    """Return the shared handle for a well-known cursor resource."""
+
+    try:
+        import ctypes
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+
+    cached = _STANDARD_CURSOR_HANDLE_CACHE.get(resource_id)
+    if cached is not None:
+        return cached
+
+    try:
+        handle = user32.LoadCursorW(None, ctypes.c_void_p(resource_id))
+    except Exception:  # pragma: no cover - defensive guard
+        cached = None
+    else:
+        if not handle:
+            cached = None
+        else:
+            cached = int(ctypes.cast(handle, ctypes.c_void_p).value or 0)
+
+    _STANDARD_CURSOR_HANDLE_CACHE[resource_id] = cached
+    return cached
+
+
+def _detect_cursor_shape(user32, handle_int: int) -> CursorShape:
+    """Map a cursor handle to a symbolic Windows cursor shape if possible."""
+
+    if not handle_int:
+        return None
+
+    try:
+        import ctypes  # noqa: WPS433 - used for pointer comparison
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+
+    mapping = {
+        "arrow": 32512,  # IDC_ARROW
+        "ibeam": 32513,  # IDC_IBEAM
+        "link": 32649,  # IDC_HAND
+    }
+
+    for shape, resource_id in mapping.items():
+        std_handle = _load_standard_cursor_handle(user32, resource_id)
+        if std_handle and std_handle == handle_int:
+            return shape
+
+    return None


### PR DESCRIPTION
## Summary
- add cursor shape detection and fallback Aero cursor resources for the Qt UI when the system cursor pixmap cannot be captured
- propagate cursor shape/handle information through the core service so the screen share track can mirror Windows cursor changes
- extend the screen share track to manage multiple cursor images and apply the correct icon (arrow, I-beam, link or system) during capture

## Testing
- python -m compileall vativision_pro/ui/cursor_utils.py vativision_pro/media/screenshare.py vativision_pro/ui/main_window.py vativision_pro/core.py

------
https://chatgpt.com/codex/tasks/task_e_68daaa5d6f5483278551ea3c7bd12861