### PR TITLE
Include media assets when building the executable

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -50,6 +50,13 @@ def _build_arguments(script: Path, *, icon: Path | None, name: str | None) -> Li
     if logo_path.exists():
         args.extend(["--add-data", _format_add_data(logo_path, ".")])
 
+    media_dir = REPO_ROOT / "vativision_pro" / "media"
+    if media_dir.exists():
+        args.extend([
+            "--add-data",
+            _format_add_data(media_dir, "vativision_pro/media"),
+        ])
+
     args.append(str(script))
     return args
 


### PR DESCRIPTION
## Summary
- ensure the PyInstaller build bundles the vativision_pro/media directory so audio assets ship in the executable

## Testing
- python build_exe.py --help

------
https://chatgpt.com/codex/tasks/task_e_68dab14395a083279b3afa4dcfee88c3